### PR TITLE
ci: set real dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10947,7 +10947,7 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
-        "@jamiemagee/osv-offline-db": "*",
+        "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
         "@octokit/rest": "18.12.0",
         "adm-zip": "^0.5.9",
         "fs-extra": "10.0.0",
@@ -10984,7 +10984,7 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
-        "@jamiemagee/osv-offline-db": "*",
+        "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
         "@octokit/rest": "18.12.0",
         "@seald-io/nedb": "3.0.0-6",
         "adm-zip": "0.5.9",
@@ -11517,7 +11517,7 @@
     "@jamiemagee/osv-offline": {
       "version": "file:packages/osv-offline",
       "requires": {
-        "@jamiemagee/osv-offline-db": "*",
+        "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
         "@octokit/rest": "18.12.0",
         "@types/adm-zip": "0.4.34",
         "@types/fs-extra": "9.0.13",
@@ -11566,7 +11566,7 @@
     "@jamiemagee/osv-offline-updater": {
       "version": "file:packages/osv-offline-updater",
       "requires": {
-        "@jamiemagee/osv-offline-db": "*",
+        "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
         "@octokit/rest": "18.12.0",
         "@seald-io/nedb": "3.0.0-6",
         "@tsconfig/node14": "1.0.1",

--- a/packages/osv-offline-updater/package.json
+++ b/packages/osv-offline-updater/package.json
@@ -8,7 +8,7 @@
     "start": "ts-node ./src/index.ts"
   },
   "dependencies": {
-    "@jamiemagee/osv-offline-db": "*",
+    "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
     "@octokit/rest": "18.12.0",
     "@seald-io/nedb": "3.0.0-6",
     "adm-zip": "0.5.9",

--- a/packages/osv-offline/package.json
+++ b/packages/osv-offline/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@jamiemagee/osv-offline-db": "*",
+    "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
     "@octokit/rest": "18.12.0",
     "adm-zip": "^0.5.9",
     "fs-extra": "10.0.0",


### PR DESCRIPTION
Instead of using `*` as a dependency version, use `0.0.0-semantic-release`. It is still a valid version locally, but should get overridden by multi-semantic-release at publish time
