### PR TITLE
chore: cache dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-node@v3.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
       - run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-node@v3.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
       - run: npm ci
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v3.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
       - run: npm ci
 


### PR DESCRIPTION
## Changes:

- Cache dependencies to speed up builds/tests

## Context:

This should reduce time needed for the "getting npm packages" step.

<details><summary>Click me to expand the docs</summary>

> ## Caching packages dependencies
> 
> The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under the hood for caching dependencies but requires less configuration settings. Supported package managers are `npm`, `yarn`, `pnpm` (v6.10+). The `cache` input is optional, and caching is turned off by default.
> 
> The action defaults to search for the dependency file (`package-lock.json` or `yarn.lock`) in the repository root, and uses its hash as a part of the cache key. Use `cache-dependency-path` for cases when multiple dependency files are used, or they are located in different subdirectories.
> 
> See the examples of using cache for `yarn` / `pnpm` and  `cache-dependency-path` input in the [Advanced usage](docs/advanced-usage.md#caching-packages-dependencies) guide.
> 
> **Caching npm dependencies:**
> ```yaml
> steps:
> - uses: actions/checkout@v2
> - uses: actions/setup-node@v2
>   with:
>     node-version: '14'
>     cache: 'npm'
> - run: npm install
> - run: npm test
> ```
> 
> **Caching npm dependencies in monorepos:**
> ```yaml
> steps:
> - uses: actions/checkout@v2
> - uses: actions/setup-node@v2
>   with:
>     node-version: '14'
>     cache: 'npm'
>     cache-dependency-path: subdir/package-lock.json
> - run: npm install
> - run: npm test
> ```

</details>

[Documentation for `setup-node` caching](https://github.com/actions/setup-node#caching-packages-dependencies)